### PR TITLE
Update NetSdrClient.cs

### DIFF
--- a/NetSdrClientApp/NetSdrClient.cs
+++ b/NetSdrClientApp/NetSdrClient.cs
@@ -130,7 +130,7 @@ namespace NetSdrClientApp
             }
         }
 
-        private TaskCompletionSource<byte[]> responseTaskSource;
+        private TaskCompletionSource<byte[]>? responseTaskSource;
 
         private async Task<byte[]> SendTcpRequest(byte[] msg)
         {


### PR DESCRIPTION
Added readonly до полів _tcpClient та _udpClient
Changed тип responseTaskSource на nullable: TaskCompletionSource<byte[]>?
Enables maintainability: Явно показує намір розробника щодо незмінності
полів
Null-safety: Правильна робота з nullable reference types відповідно до C# 8.0+
Захист від помилок: Компілятор запобігає випадковим змінам та null
reference exceptions
Thread-safety: Readonly поля безпечніші в багатопотоковому середовищі